### PR TITLE
Added addAvailableContentType REST method to the ContentTypes class

### DIFF
--- a/src/sharepoint/rest/contenttypes.ts
+++ b/src/sharepoint/rest/contenttypes.ts
@@ -25,6 +25,25 @@ export class ContentTypes extends QueryableCollection {
         ct.concat(`('${id}')`);
         return ct;
     }
+
+    /**
+     * Adds an existing contenttype to a list
+     * 
+     * @param contentTypeId in the following format, for example: 0x010102
+     */
+    public addAvailableContentType(contentTypeId: string): Promise<ContentTypeAddResult> {
+
+        let postBody: string = JSON.stringify({
+            "contentTypeId": contentTypeId,
+        });
+
+        return new ContentTypes(this, `addAvailableContentType`).postAs<any, { Id: string }>({ body: postBody }).then((data) => {
+            return {
+                data: data,
+                field: this.getById(data.Id),
+            };
+        });
+    }
 }
 
 /**
@@ -219,4 +238,8 @@ export class ContentType extends QueryableInstance {
     public get stringId(): Queryable {
         return new Queryable(this, "stringId");
     }
+}
+
+export interface ContentTypeAddResult {
+    data: any;
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| New feature?    | yes

#### What's in this Pull Request?

I've added the following REST API call to the ContentTypes class: addAvailableContentType (https://msdn.microsoft.com/en-us/library/office/jj246551.aspx).

I've tested the code on SPO with the following code: 
`$pnp.sp.web.lists.getByTitle("TestCT").contentTypes.addAvailableContentType("0x010102");`

I was wondering if it's also possible to create a contenttype using the PnP-JS-Core library. For now I'm using the CSOM version to create the contenttypes and then I can use the above method to add the created CT to a list. But it would be nice if it was possible to create a CT using pure REST.
