### PR TITLE
Body not included in request in SPRequestExecutorClient

### DIFF
--- a/src/net/sprequestexecutorclient.ts
+++ b/src/net/sprequestexecutorclient.ts
@@ -48,9 +48,9 @@ export class SPRequestExecutorClient implements HttpClientImpl {
             };
 
             if (options.body) {
-                Util.extend(requestOptions, { body: options.body });
+                requestOptions = Util.extend(requestOptions, { body: options.body });
             } else {
-                Util.extend(requestOptions, { binaryStringRequestBody: true });
+                requestOptions = Util.extend(requestOptions, { binaryStringRequestBody: true });
             }
             executor.executeAsync(requestOptions);
         });


### PR DESCRIPTION
Bug fix for the following commit, https://github.com/SharePoint/PnP-JS-Core/commit/fe7299dd8fb57f37e2a450b91d2cbd955acef4d9



