### PR TITLE
Search fluent api concept intro

### DIFF
--- a/src/sharepoint/rest/attachmentfiles.ts
+++ b/src/sharepoint/rest/attachmentfiles.ts
@@ -68,7 +68,6 @@ export class AttachmentFile extends QueryableInstance {
      * 
      */
     public getText(): Promise<string> {
-
         return new AttachmentFile(this, "$value").get(new TextFileParser());
     }
 
@@ -77,7 +76,6 @@ export class AttachmentFile extends QueryableInstance {
      * 
      */
     public getBlob(): Promise<Blob> {
-        
         return new AttachmentFile(this, "$value").get(new BlobFileParser());
     }
 
@@ -85,7 +83,6 @@ export class AttachmentFile extends QueryableInstance {
      * Gets the contents of a file as an ArrayBuffer, works in Node.js
      */
     public getBuffer(): Promise<ArrayBuffer> {
-
         return new AttachmentFile(this, "$value").get(new BufferFileParser());
     }
 
@@ -93,7 +90,6 @@ export class AttachmentFile extends QueryableInstance {
      * Gets the contents of a file as an ArrayBuffer, works in Node.js
      */
     public getJSON(): Promise<any> {
-
         return new AttachmentFile(this, "$value").get(new JSONFileParser());
     }
 

--- a/src/sharepoint/rest/rest.ts
+++ b/src/sharepoint/rest/rest.ts
@@ -51,6 +51,18 @@ export class Rest {
     }
 
     /**
+     * Begins search query fluent method
+     *
+     * @param query The SearchQuery definition
+     */
+    public searchAdv(query: string | SearchQuery): Search {
+        let search = new Search("");
+        search.setQuery(query);
+
+        return search;
+    }
+
+    /**
      * Begins a site collection scoped REST request
      *
      */

--- a/src/sharepoint/rest/search.ts
+++ b/src/sharepoint/rest/search.ts
@@ -235,7 +235,7 @@ export class Search extends QueryableInstance {
 
     /**
      * Creates a new instance of the Search class
-     * 
+     *
      * @param baseUrl The url for the search context
      * @param query The SearchQuery object to execute
      */
@@ -244,10 +244,19 @@ export class Search extends QueryableInstance {
     }
 
     /**
-     * .......
+     *
      * @returns Promise
      */
-    public execute(query: SearchQuery): Promise<SearchResults> {
+    public execute(query?: SearchQuery): Promise<SearchResults> {
+
+        // Used with alternative search
+        if (typeof query === "undefined" && typeof this.searchQuery !== "undefined") {
+            if (typeof this.pageNumValue !== "undefined") {
+                this.searchQuery.RowLimit = this.searchQuery.RowLimit || 10;
+                this.searchQuery.StartRow = this.searchQuery.RowLimit * (this.pageNumValue - 1) + 1;
+            }
+            query = this.searchQuery;
+        }
 
         let formattedBody: any;
         formattedBody = query;
@@ -284,10 +293,70 @@ export class Search extends QueryableInstance {
 
         return this.post({ body: postBody }).then((data) => new SearchResults(data));
     }
+
+    /**
+     * Skips the specified number of search results items
+     * 
+     * @param startRow The an amount or rows to skip during search request
+     */
+    public startRow(startRow: number): this {
+        this.searchQuery.StartRow = startRow;
+        return this;
+    }
+
+    /**
+     * Sets search results limit
+     * 
+     * @param rowLimit Limit or rows in a result returned from search
+     */
+    public rowLimit(rowLimit: number): this {
+        this.searchQuery.RowLimit = rowLimit;
+        return this;
+    }
+
+    /**
+     * Sets search results limit
+     * 
+     * @param pageNum Limit or rows in a result returned from search
+     */
+    public pageNum(pageNum: number): this {
+        this.pageNumValue = pageNum;
+        return this;
+    }
+
+    /**
+     * Stores search query options
+     * Used with alternative search
+     */
+    private searchQuery: SearchQuery;
+
+    /**
+     * Stores paged request page number
+     * Used with alternative search
+     */
+    private pageNumValue: number;
+
+    /**
+     * Sets search query options
+     *
+     * @param query The SearchQuery definition
+     */
+    public setQuery(query: string | SearchQuery): this {
+        let finalQuery: SearchQuery;
+
+        if (typeof query === "string") {
+            finalQuery = { Querytext: query };
+        } else {
+            finalQuery = query;
+        }
+
+        this.searchQuery = finalQuery;
+        return this;
+    };
 }
 
 /**
- * Describes the SearchResults class, which returns the formatted and raw version of the query response 
+ * Describes the SearchResults class, which returns the formatted and raw version of the query response
  */
 export class SearchResults {
 
@@ -331,7 +400,7 @@ export class SearchResults {
 }
 
 /**
- * Describes the SearchResult class 
+ * Describes the SearchResult class
  */
 export class SearchResult {
 
@@ -348,7 +417,7 @@ export class SearchResult {
 }
 
 /**
- * Defines how search results are sorted.
+ * Defines how search results are sorted
  */
 export interface Sort {
 


### PR DESCRIPTION
| Q                       | A
| ----------------- | ---
| Bug fix?             | [ ]
| New feature?     | [x]
| New sample?     | [x]
| Related issues?  | mentioned in #207

#### What's in this Pull Request?

This PR introduces the concept which allows adding some fluent wrapper to search API, such as `startRow`, `rowLimit`, `pageNum` options for search queryable instance.

#### Guidance

`search` method in `Rest` class returns SearchResults promise, which prevents adding any additional options to a query in a fluent way.
An alternative approach is applied - `searchAdv` method is added to Rest class.
`searchAdv` returns Search object, allowing to define additional properties in a chain before actual execute.

#### Examples

#### Skipping results, defining results amount on a page

```javascript
var query = "*"; // or SearchQuery interface { Querytext: "*", ... }
$pnp.sp.searchAdv(query)
     .startRow(3) // An equivalent of providing StartRow property in SearchQuery options
     .rowLimit(7) // An equivalent of providing RowLimit property in SearchQuery options
     .execute().then(function(res) { 
           // Results of a search query processing
           // Will return 7 search results, 3 rows will be skipped
     });
```

#### Pagination helper

```javascript
var query = "*"; // or SearchQuery interface { Querytext: "*", ... }
$pnp.sp.searchAdv(query)
     // .rowLimit(15) // An equivalent of providing RowLimit property in SearchQuery options
     // When RowLimit is omited and pageNum is used a default value of 10 for RowLimit is used.
     // When pageNum is used StartRow setting declaration is ignored, value of StartRow is calculated automatically based on pageNum and RowLimit values. 
     .pageNum(2)
     .execute().then(function(res) { 
           // Results of a search query processing
           // Will return 10 search results, 10 rows will be skipped, showing a content for "2nd page"
     });
```

