### PR TITLE
Site ContextInfo fix

### DIFF
--- a/src/sharepoint/rest/site.ts
+++ b/src/sharepoint/rest/site.ts
@@ -41,7 +41,7 @@ export class Site extends QueryableInstance {
      * Gets the context information for the site.
      */
     public getContextInfo(): Promise<ContextInfo> {
-        let q = new Site("", "_api/contextinfo");
+        let q = new Site(this.parentUrl, "_api/contextinfo");
         return q.post().then(data => {
             if (data.hasOwnProperty("GetContextWebInformation")) {
                 let info = data.GetContextWebInformation;


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #X, partially #Y, mentioned in #Z

#### What's in this Pull Request?

When accessing another site collection from the current context, the returned ContextInfo was still using the current context.

new Site("https://contoso.sharepoint.com").getContextInfo().then((context: ContextInfo) => {
	console.log(context);
})
