### PR TITLE
Allow configuration of custom HttpClientImpl

### DIFF
--- a/src/configuration/pnplibconfig.ts
+++ b/src/configuration/pnplibconfig.ts
@@ -1,11 +1,13 @@
 import { TypedHash } from "../collections/collections";
+import { HttpClientImpl } from "../net/httpclient";
 
 declare var global: any;
 
 export interface NodeClientData {
-    clientId: string;
-    clientSecret: string;
+    clientId?: string;
+    clientSecret?: string;
     siteUrl: string;
+    httpClient?: HttpClientImpl;
 }
 
 export interface LibraryConfiguration {

--- a/src/net/httpclient.ts
+++ b/src/net/httpclient.ts
@@ -139,10 +139,12 @@ export class HttpClient {
     }
 
     protected getFetchImpl(): HttpClientImpl {
+        let opts = RuntimeConfig.nodeRequestOptions;
         if (RuntimeConfig.useSPRequestExecutor) {
             return new SPRequestExecutorClient();
-        } else if (RuntimeConfig.useNodeFetchClient) {
-            let opts = RuntimeConfig.nodeRequestOptions;
+        } else if (RuntimeConfig.useNodeFetchClient && opts && opts.httpClient) {
+            return RuntimeConfig.nodeRequestOptions.httpClient;
+        } else if (RuntimeConfig.useNodeFetchClient && opts && opts.clientId && opts.clientSecret) {
             return new NodeFetchClient(opts.siteUrl, opts.clientId, opts.clientSecret);
         } else {
             return new FetchClient();


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [ ]
| New feature?    | [x]
| New sample?      | [x]
| Related issues?  | 

#### What's in this Pull Request?

This PR allows configuration of a custom HttpClientImpl for usage in the node client. Usage scenarios includes connection based authentication eg. NTLM.

#### Example

```
let httpClient = new MyFetchClient();

// configure your node options
pnp.setup({
    nodeClientOptions: {
        siteUrl: settings.testing.siteUrl,
        httpClient: httpClient
    }
});
```