### PR TITLE
Allow setting of custom HttpClientImpl

### DIFF
--- a/debug/debug.ts
+++ b/debug/debug.ts
@@ -1,6 +1,7 @@
 declare var require: any;
 import pnp from "../src/pnp";
 import { Logger, LogLevel, ConsoleListener } from "../src/utils/logging";
+import { NodeFetchClient } from "../src/net/nodefetchclient";
 
 // setup the connection to SharePoint using the settings file, you can
 // override any of the values as you want here, just be sure not to commit
@@ -12,10 +13,8 @@ let settings = require("../../settings.js");
 
 // configure your node options
 pnp.setup({
-    nodeClientOptions: {
-        clientId: settings.testing.clientId,
-        clientSecret: settings.testing.clientSecret,
-        siteUrl: settings.testing.siteUrl
+    fetchClientFactory: () => {
+        return new NodeFetchClient(settings.testing.siteUrl, settings.testing.clientId, settings.testing.clientSecret);
     }
 });
 

--- a/src/net/httpclient.ts
+++ b/src/net/httpclient.ts
@@ -1,9 +1,6 @@
-import { FetchClient } from "./fetchclient";
 import { DigestCache } from "./digestcache";
 import { Util } from "../utils/util";
 import { RuntimeConfig } from "../configuration/pnplibconfig";
-import { SPRequestExecutorClient } from "./sprequestexecutorclient";
-import { NodeFetchClient } from "./nodefetchclient";
 import { APIUrlException } from "../utils/exceptions";
 
 export interface FetchOptions {
@@ -21,7 +18,7 @@ export class HttpClient {
     private _impl: HttpClientImpl;
 
     constructor() {
-        this._impl = this.getFetchImpl();
+        this._impl = RuntimeConfig.fetchClientFactory();
         this._digestCache = new DigestCache(this);
     }
 
@@ -136,17 +133,6 @@ export class HttpClient {
     public delete(url: string, options: FetchOptions = {}): Promise<Response> {
         let opts = Util.extend(options, { method: "DELETE" });
         return this.fetch(url, opts);
-    }
-
-    protected getFetchImpl(): HttpClientImpl {
-        if (RuntimeConfig.useSPRequestExecutor) {
-            return new SPRequestExecutorClient();
-        } else if (RuntimeConfig.useNodeFetchClient) {
-            let opts = RuntimeConfig.nodeRequestOptions;
-            return new NodeFetchClient(opts.siteUrl, opts.clientId, opts.clientSecret);
-        } else {
-            return new FetchClient();
-        }
     }
 
     private mergeHeaders(target: Headers, source: any): void {

--- a/src/net/nodefetchclient.ts
+++ b/src/net/nodefetchclient.ts
@@ -29,6 +29,9 @@ export class NodeFetchClient implements HttpClientImpl {
         global.Headers = nodeFetch.Headers;
         global.Request = nodeFetch.Request;
         global.Response = nodeFetch.Response;
+        global._spPageContextInfo = {
+            webAbsoluteUrl: siteUrl,
+        };
     }
 
     public fetch(url: string, options: any): Promise<Response> {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,8 +1,10 @@
 export * from "../sharepoint/index";
 export { FetchOptions, HttpClient } from "../net/httpclient";
+export { SPRequestExecutorClient } from "../net/sprequestexecutorclient";
+export { NodeFetchClient } from "../net/nodefetchclient";
 export { IConfigurationProvider } from "../configuration/configuration";
 export * from "../configuration/providers/index";
-export { NodeClientData, LibraryConfiguration } from "../configuration/pnplibconfig";
+export { LibraryConfiguration } from "../configuration/pnplibconfig";
 export { TypedHash, Dictionary } from "../collections/collections";
 export { Util } from "../utils/util";
 export * from "../utils/logging";

--- a/webpack-serve.config.js
+++ b/webpack-serve.config.js
@@ -18,7 +18,7 @@ module.exports = {
         extensions: ['', '.ts']
     },
     plugins: [
-        new webpack.NormalModuleReplacementPlugin(/\.\/nodefetchclient/, "./nodefetchclientbrowser"),
+        new webpack.NormalModuleReplacementPlugin(/\.\.\/net\/nodefetchclient/, "../net/nodefetchclientbrowser"),
     ],
     module: {
         loaders: [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,7 +18,7 @@ module.exports = [{
         extensions: ['', '.js']
     },
     plugins: [
-        new webpack.NormalModuleReplacementPlugin(/\.\/nodefetchclient/, "./nodefetchclientbrowser"),
+        new webpack.NormalModuleReplacementPlugin(/\.\.\/net\/nodefetchclient/, "../net/nodefetchclientbrowser"),
         new webpack.BannerPlugin(config.header, { entryOnly: true, raw: true })
     ],
     module: {
@@ -43,7 +43,7 @@ module.exports = [{
         extensions: ['', '.js']
     },
     plugins: [
-        new webpack.NormalModuleReplacementPlugin(/\.\/nodefetchclient/, "./nodefetchclientbrowser"),
+        new webpack.NormalModuleReplacementPlugin(/\.\.\/net\/nodefetchclient/, "../net/nodefetchclientbrowser"),
         new webpack.BannerPlugin(config.header, { entryOnly: true, raw: true }),
         new webpack.DefinePlugin({
             "process.env": {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [ ]
| New feature?    | [ X]
| New sample?      | [ ]
| Related issues?  | 

#### What's in this Pull Request?

Updates the config to allow one to set any HttpClientImpl at runtime using a factory function.

```
...
import { NodeFetchClient } from "../src/net/nodefetchclient";
...

// configure your node options
pnp.setup({
    fetchClientFactory: () => {
        return new NodeFetchClient(settings.testing.siteUrl, settings.testing.clientId, settings.testing.clientSecret);
    }
});
```
