### PR TITLE
Update to support a global .d.ts shim for the $pnp global. As discuss…

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -14,6 +14,7 @@ webpack-serve.config.js
 .vscode/
 coverage/
 src/
+assets/
 tests/
 gulptasks/
 docs/

--- a/assets/pnp-global-shim.d.ts
+++ b/assets/pnp-global-shim.d.ts
@@ -1,0 +1,3 @@
+/// <reference path="pnp.d.ts" />
+export * from "pnp";
+export as namespace $pnp;

--- a/bower.json
+++ b/bower.json
@@ -33,6 +33,7 @@
         "server-root/",
         "src/",
         "tests/",
+        "assets",
         "typings.json",
         "gulptasks/",
         "typings.json",

--- a/gulptasks/@configuration.js
+++ b/gulptasks/@configuration.js
@@ -32,6 +32,7 @@ module.exports = {
         lib: "./lib",
         source: "./src",
         sourceGlob: "./src/**/*.ts",
+        assetsGlob: "./assets/**/*.*"
     },
     testing: {
         testsSource: "./tests",

--- a/gulptasks/package.js
+++ b/gulptasks/package.js
@@ -17,7 +17,6 @@ gulp.task("package:defs", () => {
     var typingsProject = tsc.createProject('tsconfig.json', { "declaration": true, "outFile": "pnp.js", "removeComments": false, "module": "system" });
 
     gulp.src(config.paths.sourceGlob).pipe(typingsProject()).dts.pipe(gulp.dest(config.paths.dist));
-    
 });
 
 // package the code files using webpack
@@ -28,7 +27,7 @@ gulp.task("package:code", ["build:lib"], (done) => {
         if (err) {
             throw new gutil.PluginError("package:code", err);
         }
-            
+
         console.log(stats.toString({
             colors: true
         }));
@@ -37,8 +36,13 @@ gulp.task("package:code", ["build:lib"], (done) => {
     });
 });
 
+// package the assets to dist
+gulp.task("package:assets", () => {
+    gulp.src(config.paths.assetsGlob).pipe(gulp.dest(config.paths.dist));
+});
+
 // used by the sync task to rebuild code
 gulp.task("package:sync", ["package:code"]);
 
 // run the package chain
-gulp.task("package", ["clean", "lint", "package:code", "package:defs"]);
+gulp.task("package", ["clean", "lint", "package:code", "package:defs", "package:assets"]);


### PR DESCRIPTION
…ed in #330

| Q               | A
| --------------- | ---
| Bug fix?        | [ ]
| New feature?    | [ X]
| New sample?      | [ ]
| Related issues?  | addresses #330 

#### What's in this Pull Request?

Adds an assets folder which is copied to dist on package, puts a shim file in that folder and ignores that folder in bower and npm.