### PR TITLE
Added delete method to ContentType

### DIFF
--- a/src/sharepoint/contenttypes.ts
+++ b/src/sharepoint/contenttypes.ts
@@ -121,13 +121,10 @@ export class ContentType extends QueryableInstance {
 
     /**
      * Delete this content type
-     *
-     * @param eTag Value used in the IF-Match header, by default "*"
      */
-    public delete(eTag = "*"): Promise<void> {
+    public delete(): Promise<void> {
         return this.post({
             headers: {
-                "IF-Match": eTag,
                 "X-HTTP-Method": "DELETE",
             },
         });

--- a/src/sharepoint/contenttypes.ts
+++ b/src/sharepoint/contenttypes.ts
@@ -118,6 +118,20 @@ export class ContentType extends QueryableInstance {
     public get workflowAssociations(): QueryableCollection {
         return new QueryableCollection(this, "workflowAssociations");
     }
+
+    /**
+     * Delete this content type
+     *
+     * @param eTag Value used in the IF-Match header, by default "*"
+     */
+    public delete(eTag = "*"): Promise<void> {
+        return this.post({
+            headers: {
+                "IF-Match": eTag,
+                "X-HTTP-Method": "DELETE",
+            },
+        });
+    }
 }
 
 export interface ContentTypeAddResult {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [ ]
| New feature?    | [ x]
| New sample?      | [ ]
| Related issues?  | fixes #X, partially #Y, mentioned in #Z

#### What's in this Pull Request?
JS Provisioning needs to be able to remove content types from a list instance in order to support RemoveExistingContentTypes.