### PR TITLE
deleting .babelrc as babel is no longer used and was causing errors for folks

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,0 @@
-{
-    "presets": [
-        "latest"
-    ]
-}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [X]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #400

#### What's in this Pull Request?

removes the babelrc file. We are no longer using babel and this was causing issues for some folks packaging things.