### PR TITLE
Support all property types on search

### DIFF
--- a/src/sharepoint/search.ts
+++ b/src/sharepoint/search.ts
@@ -376,7 +376,7 @@ export interface SearchProperty {
 }
 
 /**
- * Defines one search property value
+ * Defines one search property value. Set only one of StrlVal/BoolVal/IntVal/StrArray.
  */
 export interface SearchPropertyValue {
     StrVal?: string;

--- a/src/sharepoint/search.ts
+++ b/src/sharepoint/search.ts
@@ -379,7 +379,10 @@ export interface SearchProperty {
  * Defines one search property value
  */
 export interface SearchPropertyValue {
-    StrVal: string;
+    StrVal?: string;
+    BoolVal?: boolean;
+    Intval?: number;
+    StrArray?: string[];
     QueryPropertyValueTypeIndex: QueryPropertyValueType;
 }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| New feature?    | [x]

#### What's in this Pull Request?

SearchPropertyValue can be of other types besides string as per https://msdn.microsoft.com/en-us/library/microsoft.sharepoint.client.search.query.querypropertyvalue_members.aspx. Added all types and set them to optional so you can pick one.