### PR TITLE
config.hasOwnProperty check "spFXContext" string replaced by "spfxContext"

### DIFF
--- a/src/configuration/pnplibconfig.ts
+++ b/src/configuration/pnplibconfig.ts
@@ -87,7 +87,7 @@ export class RuntimeConfigImpl {
             this._baseUrl = config.baseUrl;
         }
 
-        if (config.hasOwnProperty("spFXContext")) {
+        if (config.hasOwnProperty("spfxContext")) {
             this._spfxContext = config.spfxContext;
         }
     }


### PR DESCRIPTION
The upper letters "FX" in config.hasOwnProperty("spFXContext ") check in file src/configuration/pnplibconfig.ts were the reason the pnp.setup not to pick the custom spfxContext for spfx webpart. 

| Q               | A
| --------------- | ---
| Bug fix?        | [X ]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #X, partially #Y, mentioned in #Z

#### What's in this Pull Request?

Small bug fix related to issue https://github.com/SharePoint/PnP-JS-Core/issues/411