### PR TITLE
Adding support for openWebById method on Site

### DIFF
--- a/gulptasks/publish.js
+++ b/gulptasks/publish.js
@@ -162,7 +162,7 @@ function engine(tasks, rl) {
 
     task();
 
-    if (tasks.length > 0) {
+    if (tasks.length > 1) {
 
         rl.question('Do you want to continue? (/^y(es)?$/i): ', (answer) => {
             if (answer.match(/^y(es)?$/i)) {
@@ -174,6 +174,10 @@ function engine(tasks, rl) {
                 tasks.pop()();
             }
         });
+    } else if (tasks.length === 1) {
+
+        // run the final cleanup and shutdown task.
+        tasks.pop()();
     }
 }
 

--- a/src/sharepoint/files.ts
+++ b/src/sharepoint/files.ts
@@ -133,7 +133,7 @@ export class File extends QueryableShareableFile {
      *
      * @param comment The comment for the approval.
      */
-    public approve(comment: string): Promise<void> {
+    public approve(comment = ""): Promise<void> {
         return this.clone(File, `approve(comment='${comment}')`, true).post();
     }
 

--- a/src/sharepoint/index.ts
+++ b/src/sharepoint/index.ts
@@ -108,7 +108,8 @@ export {
 } from "./searchsuggest";
 
 export {
-    Site
+    Site,
+    OpenWebByIdResult
 } from "./site";
 
 export {

--- a/src/sharepoint/site.ts
+++ b/src/sharepoint/site.ts
@@ -2,7 +2,7 @@ import { Queryable, QueryableInstance } from "./queryable";
 import { Web } from "./webs";
 import { UserCustomActions } from "./usercustomactions";
 import { ContextInfo, DocumentLibraryInformation } from "./types";
-import { ODataBatch } from "./odata";
+import { ODataBatch, extractOdataId } from "./odata";
 import { Features } from "./features";
 
 /**
@@ -101,4 +101,28 @@ export class Site extends QueryableInstance {
     public createBatch(): ODataBatch {
         return new ODataBatch(this.parentUrl);
     }
+
+    /**
+     * Opens a web by Id (using POST)
+     *
+     * @param webId The GUID id fo the web to open
+     */
+    public openWebById(webId: string): Promise<OpenWebByIdResult> {
+
+        return this.clone(Site, `openWebById('${webId}')`, true).post().then(d => {
+
+            return {
+                data: d,
+                web: Web.fromUrl(extractOdataId(d)),
+            };
+        });
+    }
+}
+
+/**
+ * The result of opening a web by id, contains the data retruned as well as a chainable web instance
+ */
+export interface OpenWebByIdResult {
+    data: any;
+    web: Web;
 }

--- a/tests/sharepoint/site.test.ts
+++ b/tests/sharepoint/site.test.ts
@@ -37,5 +37,21 @@ describe("Site", () => {
                 return expect(pnp.sp.site.getWebUrlFromPageUrl(pageUrl)).to.eventually.equal(testSettings.webUrl.replace(/\/$/, ""));
             });
         });
+
+        describe("openWebById", () => {
+            it("should get a web by id", () => {
+
+                const chain = pnp.sp.web.select("Id").get().then(w => {
+
+                    return pnp.sp.site.openWebById(w.Id).then(ww => {
+
+                        // prove that we can successfully chain from the Web instance
+                        return ww.web.select("Title").get();
+                    });
+                });
+
+                return expect(chain).to.eventually.be.fulfilled;
+            });
+        });
     }
 });


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [ ]
| New feature?    | [X]
| New sample?      | [ ]
| Related issues?  | fixes #422 

#### What's in this Pull Request?

Adds support for the openWebById method. Usage:

```TypeScript
pnp.sp.site.openWebById("155cb453-90f5-482e-a380-cee1ff383a9e").then(ww => {

    //we got all the data from the web as well
    console.log(ww.data);

    // we can chain
    ww.web.select("Title").get();
});
```

