### PR TITLE
Support for getPage method on SearchResults, removed deprecated makeU…

### DIFF
--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -1,6 +1,5 @@
 declare var global: any;
 import { TypedHash } from "../collections/collections";
-import { deprecated } from "./decorators";
 import { RuntimeConfig } from "../configuration/pnplibconfig";
 
 export class Util {
@@ -120,7 +119,7 @@ export class Util {
     public static combinePaths(...paths: string[]): string {
 
         return paths
-            .filter(path => typeof path !== "undefined" && path !== null)
+            .filter(path => !Util.stringIsNullOrEmpty(path))
             .map(path => path.replace(/^[\\|\/]/, "").replace(/[\\|\/]$/, ""))
             .join("/")
             .replace(/\\/g, "/");
@@ -185,7 +184,7 @@ export class Util {
      * @param s The string to test
      */
     public static stringIsNullOrEmpty(s: string): boolean {
-        return typeof s === "undefined" || s === null || s === "";
+        return typeof s === "undefined" || s === null || s.length < 1;
     }
 
     /**
@@ -220,29 +219,6 @@ export class Util {
      */
     public static isUrlAbsolute(url: string): boolean {
         return /^https?:\/\/|^\/\//i.test(url);
-    }
-
-    /**
-     * Attempts to make the supplied relative url absolute based on the _spPageContextInfo object, if available
-     *
-     * @param url The relative url to make absolute
-     */
-    @deprecated("The Util.makeUrlAbsolute method is deprecated and will be removed from future releases. Use Util.toAbsoluteUrl instead")
-    public static makeUrlAbsolute(url: string): string {
-
-        if (Util.isUrlAbsolute(url)) {
-            return url;
-        }
-
-        if (typeof global._spPageContextInfo !== "undefined") {
-            if (global._spPageContextInfo.hasOwnProperty("webAbsoluteUrl")) {
-                return Util.combinePaths(global._spPageContextInfo.webAbsoluteUrl, url);
-            } else if (global._spPageContextInfo.hasOwnProperty("webServerRelativeUrl")) {
-                return Util.combinePaths(global._spPageContextInfo.webServerRelativeUrl, url);
-            }
-        } else {
-            return url;
-        }
     }
 
     /**

--- a/tests/utils/util.test.ts
+++ b/tests/utils/util.test.ts
@@ -63,6 +63,10 @@ describe("Util", () => {
             expect(Util.combinePaths(null, "path2", undefined, null, "/path4")).to.eq("path2/path4");
         });
 
+        it("Should combine the paths null, 'path2', undefined, \"\", null and '/path4' to be path2/path4", () => {
+            expect(Util.combinePaths(null, "path2", undefined, "", null, "/path4")).to.eq("path2/path4");
+        });
+
         it("Should not error with no arguments specified", () => {
             expect(Util.combinePaths()).to.eq("");
         });
@@ -99,6 +103,20 @@ describe("Util", () => {
             expect(Util.isFunction({ val: 0 })).to.be.false;
             expect(Util.isFunction(null)).to.be.false;
             expect(Util.isFunction(undefined)).to.be.false;
+        });
+    });
+
+    describe("isArray", () => {
+        it("Should find that an Array is an Array", () => {
+            expect(Util.isArray([1, 2, 3, 4])).to.be.true;
+        });
+
+        it("Should find that a non-Array is not an Array", () => {
+            expect(Util.isArray(null)).to.be.false;
+            expect(Util.isArray("")).to.be.false;
+            expect(Util.isArray(3)).to.be.false;
+            expect(Util.isArray({})).to.be.false;
+            expect(Util.isArray(undefined)).to.be.false;
         });
     });
 });


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [ ]
| New feature?    | [X]
| New sample?      | [ ]
| Related issues?  | fixes #207

#### What's in this Pull Request?

Support for getPage method on SearchResults, removed deprecated makeUrlAbsolute method - use toAbsoluteUrl, updates/clean-up in Util class methods
