### PR TITLE
Initial commit and update of util to parse url if it's in siteassets.

### DIFF
--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -275,9 +275,13 @@ export class Util {
                 }
             }
 
-            // does window.location exist and have _layouts in it?
+            // does window.location exist and have _layouts or site assets in it?
             if (typeof global.location !== "undefined") {
-                const index = global.location.toString().toLowerCase().indexOf("/_layouts/");
+                if (global.location.toString().toLowerCase().indexOf("/_layouts/") > 0){
+	                const index = global.location.toString().toLowerCase().indexOf("/_layouts/");
+	            }else if(global.location.toString().toLowerCase().indexOf("/siteassets/") > 0){
+	                const index = global.location.toString().toLowerCase().indexOf("/siteassets/");
+                }
                 if (index > 0) {
                     // we are likely in the workbench in /_layouts/
                     return resolve(Util.combinePaths(global.location.toString().substr(0, index), candidateUrl));


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | This allows developers to place the PnP JS file in the site assets folder.
| New feature?    | N/A
| New sample?      | N/A
| Related issues?  | N/A

#### What's in this Pull Request?

While I was developing a Knockout SPA application, I came across a bug where if the PnP JS Core files placed in the assets folder it would error out. I realised that it wasn't parsing the "site assets" URL path. This is another avenue for developers to build full page SPAs outside of the SharePoint context.


