### PR TITLE
Added a feature to apply custom headers and base url on a per-object basis

### DIFF
--- a/src/net/httpclient.ts
+++ b/src/net/httpclient.ts
@@ -3,13 +3,16 @@ import { Util } from "../utils/util";
 import { RuntimeConfig } from "../configuration/pnplibconfig";
 import { APIUrlException } from "../utils/exceptions";
 
-export interface FetchOptions {
-    method?: string;
+export interface ConfigOptions {
     headers?: string[][] | { [key: string]: string };
-    body?: any;
     mode?: "navigate" | "same-origin" | "no-cors" | "cors";
     credentials?: "omit" | "same-origin" | "include";
     cache?: "default" | "no-store" | "reload" | "no-cache" | "force-cache" | "only-if-cached";
+}
+
+export interface FetchOptions extends ConfigOptions {
+    method?: string;
+    body?: any;
 }
 
 export class HttpClient {
@@ -136,6 +139,13 @@ export class HttpClient {
         const opts = Util.extend(options, { method: "DELETE" });
         return this.fetch(url, opts);
     }
+}
+
+export function mergeOptions(target: ConfigOptions, source: ConfigOptions): void {
+    target.headers = target.headers || {};
+    const headers = Util.extend(target.headers, source.headers);
+    target = Util.extend(target, source);
+    target.headers = headers;
 }
 
 export function mergeHeaders(target: Headers, source: any): void {

--- a/src/sharepoint/rest.ts
+++ b/src/sharepoint/rest.ts
@@ -8,11 +8,44 @@ import { UserProfileQuery } from "./userprofiles";
 import { ODataBatch } from "./odata";
 import { UrlException } from "../utils/exceptions";
 import { UtilityMethod, UtilityMethods } from "./utilities";
+import { ConfigOptions } from "../pnp";
 
 /**
  * Root of the SharePoint REST module
  */
 export class SPRest {
+
+    /**
+     * Additional options to be set before sending actual http requests
+     */
+    private _options: ConfigOptions;
+
+    /**
+     * A string that should form the base part of the url
+     */
+    private _baseUrl: string;
+
+    /** 
+     * Creates a new instance of the SPRest class
+     * 
+     * @param options Additional options
+     * @param baseUrl A string that should form the base part of the url
+     */
+    constructor(options: ConfigOptions = {}, baseUrl = "") {
+        this._options = options;
+        this._baseUrl = baseUrl;
+    }
+
+    /**
+     * Configures instance with additional options and baseUrl.
+     * Provided configuration used by other objects in a chain
+     * 
+     * @param options Additional options
+     * @param baseUrl A string that should form the base part of the url
+     */
+    public configure(options: ConfigOptions, baseUrl = ""): SPRest {
+        return new SPRest(options, baseUrl);
+    }
 
     /**
      * Executes a search against this web context
@@ -29,7 +62,7 @@ export class SPRest {
             finalQuery = query;
         }
 
-        return new SearchSuggest("").execute(finalQuery);
+        return new SearchSuggest(this._baseUrl).configure(this._options).execute(finalQuery);
     }
 
     /**
@@ -43,13 +76,13 @@ export class SPRest {
 
         if (typeof query === "string") {
             finalQuery = { Querytext: query };
-        } else if (query instanceof  SearchQueryBuilder) {
+        } else if (query instanceof SearchQueryBuilder) {
             finalQuery = (query as SearchQueryBuilder).toSearchQuery();
         } else {
             finalQuery = query;
         }
 
-        return new Search("").execute(finalQuery);
+        return new Search(this._baseUrl).configure(this._options).execute(finalQuery);
     }
 
     /**
@@ -57,7 +90,7 @@ export class SPRest {
      *
      */
     public get site(): Site {
-        return new Site("");
+        return new Site(this._baseUrl).configure(this._options);
     }
 
     /**
@@ -65,7 +98,7 @@ export class SPRest {
      *
      */
     public get web(): Web {
-        return new Web("");
+        return new Web(this._baseUrl).configure(this._options);
     }
 
     /**
@@ -73,7 +106,7 @@ export class SPRest {
      *
      */
     public get profiles(): UserProfileQuery {
-        return new UserProfileQuery("");
+        return new UserProfileQuery(this._baseUrl).configure(this._options);
     }
 
     /**
@@ -88,7 +121,7 @@ export class SPRest {
      * Static utilities methods from SP.Utilities.Utility
      */
     public get utility(): UtilityMethods {
-        return new UtilityMethod("", "");
+        return new UtilityMethod(this._baseUrl, "").configure(this._options);
     }
 
     /**
@@ -137,6 +170,6 @@ export class SPRest {
 
         const instance = new factory(url, urlPart);
         instance.query.add("@target", "'" + encodeURIComponent(hostWebUrl) + "'");
-        return instance;
+        return instance.configure(this._options);
     }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,5 @@
 export * from "../sharepoint/index";
-export { FetchOptions, HttpClient, HttpClientImpl } from "../net/httpclient";
+export { ConfigOptions, FetchOptions, HttpClient, HttpClientImpl } from "../net/httpclient";
 export { SPRequestExecutorClient } from "../net/sprequestexecutorclient";
 export { NodeFetchClient } from "../net/nodefetchclient";
 export { FetchClient } from "../net/fetchclient";

--- a/tests/mocks/mockfetchclient.ts
+++ b/tests/mocks/mockfetchclient.ts
@@ -1,0 +1,24 @@
+const nodeFetch = require("node-fetch");
+declare var global: any;
+
+import { HttpClientImpl, FetchOptions } from "../../src/pnp";
+
+export class MockFetchClient implements HttpClientImpl {
+
+    public options: any;
+
+    constructor() {
+        global.Headers = nodeFetch.Headers;
+        global.Request = nodeFetch.Request;
+        global.Response = nodeFetch.Response;
+    }
+
+    public fetch(url: string, options: FetchOptions): Promise<Response> {
+        this.options = options;
+        const response = new Response("{}", {
+            status: 200,
+        });
+
+        return Promise.resolve(response);
+    }
+}

--- a/tests/sharepoint/configure.test.ts
+++ b/tests/sharepoint/configure.test.ts
@@ -1,0 +1,153 @@
+import { expect } from "chai";
+
+import { testSettings } from "../test-config.test";
+import { default as pnp, NodeFetchClient } from "../../src/pnp";
+import { MockFetchClient } from "../mocks/mockfetchclient";
+
+describe("Custom options", () => {
+    const mockFetch = new MockFetchClient();
+    const headerName = "my-header";
+    const headerValue = "my header value";
+    const headers = {};
+    headers[headerName] = headerValue;
+    headers["X-RequestDigest"] = "test";
+
+    before(() => {
+        pnp.setup({
+            fetchClientFactory: () => {
+                return mockFetch;
+            },
+        });
+    });
+
+    after(() => {
+        if (testSettings.enableWebTests) {
+            pnp.setup({
+                fetchClientFactory: () => {
+                    return new NodeFetchClient(testSettings.siteUrl, testSettings.clientId, testSettings.clientSecret);
+                },
+            });
+        }
+    });
+
+    it("Should set header when getting a web and configuring global SPRests", () => {
+        return pnp.sp.configure({
+            headers: headers,
+        }).web.get()
+            .then(() => {
+                const header = mockFetch.options.headers.get(headerName);
+                expect(header).to.equal(headerValue);
+            });
+    });
+
+    it("Should set header when getting a web and applying headers for web only", () => {
+        return pnp.sp.web.configure({
+            headers: headers,
+        }).get()
+            .then(() => {
+                const header = mockFetch.options.headers.get(headerName);
+                expect(header).to.equal(headerValue);
+            });
+    });
+
+    it("Should override header when setting headers on a web", () => {
+        const webHeaders = {};
+        webHeaders[headerName] = "web's value";
+        return pnp.sp.configure(headers).web.configure({
+            headers: webHeaders,
+        }).get()
+            .then(() => {
+                const header = mockFetch.options.headers.get(headerName);
+                expect(header).to.equal("web's value");
+            });
+    });
+
+    it("Should add another header when setting headers on a web", () => {
+        const webHeaders = {};
+        webHeaders["new-header"] = "web's value";
+        return pnp.sp.configure(headers).web.configure({
+            headers: webHeaders,
+        }).get()
+            .then(() => {
+                const header = mockFetch.options.headers.get("new-header");
+                expect(header).to.equal("web's value");
+            });
+    });
+
+    it("Should use the same header for all requests", () => {
+        const sp = pnp.sp.configure({
+            headers: headers,
+        });
+        const validate = () => {
+            const header = mockFetch.options.headers.get(headerName);
+            expect(header).to.equal(headerValue);
+            mockFetch.options = null;
+        };
+        return sp.site.get()
+            .then(() => {
+                validate();
+                return sp.web.get();
+            })
+            .then(() => {
+                validate();
+                return sp.web.fields.add("test", "Text");
+            })
+            .then(() => {
+                validate();
+            });
+    });
+
+    it("Should use different headers for requests", () => {
+        const webHeaders = {};
+        webHeaders["new-header"] = "web's value";
+        const sp = pnp.sp.configure({
+            headers: headers,
+        });
+
+        return sp.site.get()
+            .then(() => {
+                const header = mockFetch.options.headers.get(headerName);
+                expect(header).to.equal(headerValue);
+                return pnp.sp.web.get();
+            })
+            .then(() => {
+                const header = mockFetch.options.headers.get(headerName);
+                expect(header).to.be.null;
+            });
+    });
+
+    it("Should set correct options when getting a web and configuring global SPRests", () => {
+        return pnp.sp.configure({
+            cache: "no-store",
+            credentials: "omit",
+            mode: "cors",
+        }).web.get()
+            .then(() => {
+                const mode = mockFetch.options.mode;
+                const cache = mockFetch.options.cache;
+                const creds = mockFetch.options.credentials;
+
+                expect(mode).to.equal("cors");
+                expect(cache).to.equal("no-store");
+                expect(creds).to.equal("omit");
+            });
+    });
+
+    it("Should override options when applying on child objects", () => {
+        return pnp.sp.configure({
+            cache: "no-store",
+            credentials: "omit",
+            mode: "cors",
+        }).web.configure({
+            cache: "default",
+            mode: "navigate",
+        }).get()
+            .then(() => {
+                const mode = mockFetch.options.mode;
+                const cache = mockFetch.options.cache;
+
+                expect(mode).to.equal("navigate");
+                expect(cache).to.equal("default");
+            });
+    });
+});


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| New feature?    | [x]
| Related issues?  | References #499

#### What's in this Pull Request?

This PR addresses referenced issue.   
If you want to apply custom header in any particular object, you can do:   

```javascript
let groups = pnp.sp.configure({
      'myHeader': 'myvalue'
    }, 'https://my.base.com').web.siteGroups;
```  
`groups` (as well as `web` and all other objects in a chain) object will hold additional header `myHeader` and this header will be attached to actual http request.  This approach allows you to send simultaneous requests with different headers or authentication information, for example:   
```javascript
let userAccessToken = 'Bearer eyJ0eXAiO...';
let appOnlyToken: = 'Bearer eyJ0eXAiO....';
let anotherUserAccessToken = 'Bearer eyJ0eXAiO....';
let user1 = pnp.sp.configure({
	'Authorization': userAccessToken
}).utility;
let user2 = pnp.sp.configure({
	'Authorization': anotherUserAccessToken
}).utility;

Promise.all([user1.sendEmail(),  // <-- sending email on behalf of the user
			user2.sendEmail()]) // <-- sending on behalf of another user
```
Another option is to use constructor for various objects syntax:  
```javascript
new Web('').useHeaders({
      'myHeader': 'another value',
      'one more': 'val'
    });
```