### PR TITLE
Fixed issue when config isn't copied when using getParent method on Q…

### DIFF
--- a/src/sharepoint/queryable.ts
+++ b/src/sharepoint/queryable.ts
@@ -263,6 +263,8 @@ export class Queryable {
         batch?: ODataBatch): T {
 
         let parent = new factory(baseUrl, path);
+        parent.configure(this._options);
+
         const target = this.query.get("@target");
         if (target !== null) {
             parent.query.add("@target", target);

--- a/tests/sharepoint/configure.test.ts
+++ b/tests/sharepoint/configure.test.ts
@@ -40,6 +40,16 @@ describe("Custom options", () => {
             });
     });
 
+    it("Should set header when making a post request using getParent method", () => {
+        return pnp.sp.configure({
+            headers: headers,
+        }).web.features.getById("test").deactivate()
+            .then(() => {
+                const header = mockFetch.options.headers.get(headerName);
+                expect(header).to.equal(headerValue);
+            });
+    });
+
     it("Should set header when getting a web and applying headers for web only", () => {
         return pnp.sp.web.configure({
             headers: headers,


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [x]
| Related issues?  | fixes #553 

#### What's in this Pull Request?

Fixed issue when config isn't copied when using getParent method on Queryable
