### PR TITLE
moving exports back to root of package to work in umd

### DIFF
--- a/gulptasks/@configuration.js
+++ b/gulptasks/@configuration.js
@@ -32,9 +32,8 @@ module.exports = {
         lib: "./lib",
         exports: "./",
         source: "./src",
-        sourceGlob: ["./src/**/*.ts", "!./src/exports/**/*.ts"],
-        assetsGlob: "./assets/**/*.*",
-        exportsGlob: "./src/exports/**/*.ts"
+        sourceGlob: ["./src/**/*.ts"],
+        assetsGlob: "./assets/**/*.*"
     },
     testing: {
         testsSource: "./tests",

--- a/gulptasks/build.js
+++ b/gulptasks/build.js
@@ -27,20 +27,6 @@ gulp.task("build:lib", () => {
     ]);
 });
 
-gulp.task("build:exports", () => {
-
-    var project = tsc.createProject("tsconfig.json", { declaration: true });
-
-    var built = gulp.src(config.paths.exportsGlob)
-        .pipe(replace("$$Version$$", pkg.version))
-        .pipe(project());
-
-    return merge([
-        built.dts.pipe(replace("../", "./lib/")).pipe(gulp.dest(config.paths.exports)),
-        built.js.pipe(replace("../", "./lib/")).pipe(gulp.dest(config.paths.exports))
-    ]);
-});
-
 gulp.task("build:testing", () => {
 
     var projectSrc = tsc.createProject("tsconfig.json");

--- a/gulptasks/package.js
+++ b/gulptasks/package.js
@@ -20,7 +20,7 @@ gulp.task("package:defs", () => {
 });
 
 // package the code files using webpack
-gulp.task("package:code", ["build:lib", "build:exports"], (done) => {
+gulp.task("package:code", ["build:lib"], (done) => {
 
     webpack(webpackConfig, (err, stats) => {
 

--- a/src/pnp.ts
+++ b/src/pnp.ts
@@ -45,6 +45,15 @@ export const log = Logger;
  */
 export const setup: (config: LibraryConfiguration) => void = setRuntimeConfig;
 
+/**
+ * Export everything back to the top level so it can be properly bundled
+ */
+export * from "./exports/core";
+export * from "./exports/graph";
+export * from "./exports/net";
+export * from "./exports/odata";
+export * from "./exports/sp";
+
 // /**
 //  * Expose a subset of classes from the library for public consumption
 //  */


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [X]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #595

#### What's in this Pull Request?

Moves all the exports back to the root level to work with Webpack
