### PR TITLE
Added support to delete multiple attachments

### DIFF
--- a/src/sharepoint/attachmentfiles.ts
+++ b/src/sharepoint/attachmentfiles.ts
@@ -67,10 +67,8 @@ export class AttachmentFiles extends SharePointQueryableCollection {
      *
      * @files name The collection of files to delete
      */
-    public deleteMultiple(files: AttachmentFileInfo[]): Promise<void> {
-
-        // delete the files in series so we don't get update conflicts
-        return files.reduce((chain, file) => chain.then(() => this.clone(AttachmentFiles, `getByFileName('${file.name}')`).postCore({
+    public deleteMultiple(files: string[]): Promise<void> {
+        return files.reduce((chain, file) => chain.then(() => this.clone(AttachmentFiles, `getByFileName('${file}')`).postCore({
             headers: {
                 "X-HTTP-Method": "DELETE",
             },

--- a/src/sharepoint/attachmentfiles.ts
+++ b/src/sharepoint/attachmentfiles.ts
@@ -67,12 +67,11 @@ export class AttachmentFiles extends SharePointQueryableCollection {
      *
      * @files name The collection of files to delete
      */
-    public deleteMultiple(files: AttachmentFileInfo[], eTag = "*"): Promise<void> {
+    public deleteMultiple(files: AttachmentFileInfo[]): Promise<void> {
 
         // delete the files in series so we don't get update conflicts
         return files.reduce((chain, file) => chain.then(() => this.clone(AttachmentFiles, `getByFileName('${file.name}')`).postCore({
             headers: {
-                "IF-Match": eTag,
                 "X-HTTP-Method": "DELETE",
             },
         })), Promise.resolve());

--- a/src/sharepoint/attachmentfiles.ts
+++ b/src/sharepoint/attachmentfiles.ts
@@ -50,7 +50,7 @@ export class AttachmentFiles extends SharePointQueryableCollection {
     }
 
     /**
-     * Adds mjultiple new attachment to the collection. Not supported for batching.
+     * Adds multiple new attachment to the collection. Not supported for batching.
      *
      * @files name The collection of files to add
      */
@@ -59,6 +59,22 @@ export class AttachmentFiles extends SharePointQueryableCollection {
         // add the files in series so we don't get update conflicts
         return files.reduce((chain, file) => chain.then(() => this.clone(AttachmentFiles, `add(FileName='${file.name}')`, false).postCore({
             body: file.content,
+        })), Promise.resolve());
+    }
+
+    /**
+     * Delete multiple attachments from the collection. Not supported for batching.
+     *
+     * @files name The collection of files to delete
+     */
+    public deleteMultiple(files: AttachmentFileInfo[], eTag = "*"): Promise<void> {
+
+        // delete the files in series so we don't get update conflicts
+        return files.reduce((chain, file) => chain.then(() => this.clone(AttachmentFiles, `getByFileName('${file.name}')`).postCore({
+            headers: {
+                "IF-Match": eTag,
+                "X-HTTP-Method": "DELETE",
+            },
         })), Promise.resolve());
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | N
| New feature?    | Y
| New sample?   | N


#### What's in this Pull Request?

Added support to delete multiple attachments from a SharePoint list item by passing the file names. It make use of the `/AttachmentFiles/getByFileName('test.txt')` method 

Example:

```
const list = $pnp.sp.web.lists.getByTitle("MyList");

var fileInfos = ["1.txt","2.txt"];

list.items.getById(2).attachmentFiles.deleteMultiple(fileInfos).then(r => {
    console.log(r);
});
```
