### PR TITLE
Added support for /_api/web/GetStorageEntity endpoint

### DIFF
--- a/src/sharepoint/webs.ts
+++ b/src/sharepoint/webs.ts
@@ -458,6 +458,15 @@ export class Web extends SharePointQueryableShareableWeb {
     public mapToIcon(filename: string, size = 0, progId = ""): Promise<string> {
         return this.clone(Web, `maptoicon(filename='${filename}', progid='${progId}', size=${size})`).get();
     }
+
+    /**
+     * Returns the tenant property corresponding to the specified key in the app catalog site
+     * 
+     * @param key 
+     */
+    public getStorageEntity(key: string): Promise<string> {
+        return this.clone(Web, `GetStorageEntity('${key}')`).get();
+    }
 }
 
 /**

--- a/src/sharepoint/webs.ts
+++ b/src/sharepoint/webs.ts
@@ -465,7 +465,7 @@ export class Web extends SharePointQueryableShareableWeb {
      * @param key 
      */
     public getStorageEntity(key: string): Promise<string> {
-        return this.clone(Web, `GetStorageEntity('${key}')`).get();
+       return this.clone(Web, `getStorageEntity('${key}')`).get();
     }
 }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [ N ]
| New feature?    | [ Y ]
| New sample?      | [ N ]


#### What's in this Pull Request?

Added support for /_api/web/GetStorageEntity endpoint.

This addition will enable developers to get the tenant property set in the app catalog site by their key name.

For more information - [SharePoint Online Tenant Properties](https://docs.microsoft.com/en-us/sharepoint/dev/spfx/tenant-properties)

Usage:

```
$pnp.sp.web.getStorageEntity('SPFxTestApiKey').then(r => {
    console.log(r);
});

```

