### PR TITLE
Adds capability of getting external lists items by `getItemByStringId`

### DIFF
--- a/src/sharepoint/items.ts
+++ b/src/sharepoint/items.ts
@@ -37,6 +37,18 @@ export class Items extends SharePointQueryableCollection {
     }
 
     /**
+     * Gets BCS Item by string id
+     *
+     * @param stringId The string id of the BCS item to retrieve
+     */
+    public getItemByStringId(stringId: string): Item {
+        const i = new Item(this);
+        i.concat(`/../getItemByStringId('${stringId}')`);
+        return i;
+    }
+
+
+    /**
      * Skips the specified number of items (https://msdn.microsoft.com/en-us/library/office/fp142385.aspx#sectionSection6)
      *
      * @param skip The starting id where the page should start, use with top to specify pages


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?            | [ ]
| New feature?   | [x]
| New sample?   | [ ]

#### What's in this Pull Request?

When working with external lists, it's not possible to get list item with `lists.getByTitle('External List').items.getById(identity)`.
External list's item identity is a string (with format like '__bg40002300').
Currently, without feasibility of getting external lists' items by string id, it's not possible to update or delete such items and sometimes impossible to get item's data (depending on ECTs filter configuration).
External list items should be selected by BdcItentity in REST with `/_api/web/lists/getByTitle('External List')/getItemByStringId('__bg40002300')`.

This PR adds the capability of getting external lists items by `getItemByStringId` then working with an item in a usual way.


