### PR TITLE
RegionalSettings endpoint implementation, #649

### DIFF
--- a/src/sharepoint/regionalsettings.ts
+++ b/src/sharepoint/regionalsettings.ts
@@ -1,0 +1,98 @@
+import { SharePointQueryable, SharePointQueryableInstance, SharePointQueryableCollection } from "./sharepointqueryable";
+
+/**
+ * Describes regional settings ODada object
+ */
+export class RegionalSettings extends SharePointQueryableInstance {
+
+    /**
+     * Creates a new instance of the RegionalSettings class
+     *
+     * @param baseUrl The url or SharePointQueryable which forms the parent of this regional settings collection
+     */
+
+    constructor(baseUrl: string | SharePointQueryable, path = "regionalsettings") {
+        super(baseUrl, path);
+    }
+
+    /**
+     * Gets installed languages
+     */
+    public get installedLanguages(): InstalledLanguages {
+        return new InstalledLanguages(this);
+    }
+
+    /**
+     * Gets time zone
+     */
+    public get timeZone(): TimeZone {
+        return new TimeZone(this);
+    }
+
+    /**
+     * Gets time zones
+     */
+    public get timeZones(): TimeZones {
+        return new TimeZones(this);
+    }
+
+}
+
+export interface RegionalSettingsProps {
+    AdjustHijriDays: number;
+    AlternateCalendarType: number;
+    AM: string;
+    CalendarType: number;
+    Collation: number;
+    CollationLCID: number;
+    DateFormat: number;
+    DateSeparator: string;
+    DecimalSeparator: string;
+    DigitGrouping: string;
+    FirstDayOfWeek: number;
+    FirstWeekOfYear: number;
+    IsEastAsia: boolean;
+    IsRightToLeft: boolean;
+    IsUIRightToLeft: boolean;
+    ListSeparator: string;
+    LocaleId: number;
+    NegativeSign: string;
+    NegNumberMode: number;
+    PM: string;
+    PositiveSign: string;
+    ShowWeeks: boolean;
+    ThousandSeparator: string;
+    Time24: boolean;
+    TimeMarkerPosition: number;
+    TimeSeparator: string;
+    WorkDayEndHour: number;
+    WorkDays: number;
+    WorkDayStartHour: number;
+}
+
+/**
+ * Describes TimeZone ODada object
+ */
+export class TimeZone extends SharePointQueryableInstance {
+    constructor(baseUrl: string | SharePointQueryable, path = "timezone") {
+        super(baseUrl, path);
+    }
+}
+
+/**
+ * Describes installed languages ODada queriable collection
+ */
+export class InstalledLanguages extends SharePointQueryableInstance {
+    constructor(baseUrl: string | SharePointQueryable, path = "installedlanguages") {
+        super(baseUrl, path);
+    }
+}
+
+/**
+ * Describes time zones queriable collection
+ */
+export class TimeZones extends SharePointQueryableCollection {
+  constructor(baseUrl: string | SharePointQueryable, path = "timezones") {
+      super(baseUrl, path);
+  }
+}

--- a/src/sharepoint/webs.ts
+++ b/src/sharepoint/webs.ts
@@ -4,6 +4,7 @@ import { Fields } from "./fields";
 import { Navigation } from "./navigation";
 import { SiteGroups, SiteGroup } from "./sitegroups";
 import { ContentTypes } from "./contenttypes";
+import { RegionalSettings } from "./regionalsettings";
 import { Folders, Folder } from "./folders";
 import { RoleDefinitions } from "./roles";
 import { File } from "./files";
@@ -218,6 +219,13 @@ export class Web extends SharePointQueryableShareableWeb {
         return new List(this, "siteuserinfolist");
     }
 
+    /**
+     * Gets regional settings
+     *
+     */
+    public get regionalSettings(): RegionalSettings {
+        return new RegionalSettings(this);
+    }
 
     /**
      * Gets the current user

--- a/tests/sharepoint/regionalsettings.test.ts
+++ b/tests/sharepoint/regionalsettings.test.ts
@@ -1,0 +1,40 @@
+import { expect } from "chai";
+import { RegionalSettings } from "../../src/sharepoint/regionalsettings";
+import { toMatchEndRegex } from "../testutils";
+
+describe("RegionalSettings", () => {
+
+    let regionalsettings: RegionalSettings;
+
+    beforeEach(() => {
+        regionalsettings = new RegionalSettings("_api/web");
+    });
+
+    it("Should be an object", () => {
+        expect(regionalsettings).to.be.a("object");
+    });
+
+    describe("url", () => {
+        it("Should return _api/web/regionalsettings", () => {
+            expect(regionalsettings.toUrl()).to.match(toMatchEndRegex("_api/web/regionalsettings"));
+        });
+    });
+
+    describe("installedLanguages", () => {
+        it("Should return _api/web/regionalsettings/installedlanguages", () => {
+            expect(regionalsettings.installedLanguages.toUrl()).to.match(toMatchEndRegex("_api/web/regionalsettings/installedlanguages"));
+        });
+    });
+
+    describe("timeZone", () => {
+        it("Should return _api/web/regionalsettings/timezone", () => {
+            expect(regionalsettings.timeZone.toUrl()).to.match(toMatchEndRegex("_api/web/regionalsettings/timezone"));
+        });
+    });
+
+    describe("timeZones", () => {
+        it("Should return _api/web/regionalsettings/timezones", () => {
+            expect(regionalsettings.timeZones.toUrl()).to.match(toMatchEndRegex("_api/web/regionalsettings/timezones"));
+        });
+    });
+});

--- a/tests/sharepoint/web.test.ts
+++ b/tests/sharepoint/web.test.ts
@@ -66,6 +66,12 @@ describe("Web", () => {
         });
     });
 
+    describe("regionalSettings", () => {
+        it("should return _api/web/regionalsettings", () => {
+            expect(web.regionalSettings.toUrl()).to.match(toMatchEndRegex("_api/web/regionalsettings"));
+        });
+    });
+
     describe("siteUserInfoList", () => {
         it("should return _api/web/siteUserInfoList", () => {
             expect(web.siteUserInfoList.toUrl()).to.match(toMatchEndRegex("_api/web/siteuserinfolist"));


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [ ]
| New feature?    | [x]
| New sample?      | [ ]
| Related issues?  | implements #649

#### What's in this Pull Request?

This PR implements `_api/web/RegionalSettings` endpoint.

#### Guidance

```typescript
 // Get regional setting
pnp.sp.web.regionalSettings.select('LocaleId,ShowWeeks').get().then(console.log);

// Get time zone
pnp.sp.web.regionalSettings.timeZone.get().then(console.log);

// Get time zones
pnp.sp.web.regionalSettings.timeZones.top(1).get().then(console.log);

// Get installed languages
pnp.sp.web.regionalSettings.installedLanguages.get().then(langs => {
  console.log(langs.Items[0]);
});
```
