### PR TITLE
getPropertiesFor typing issue fix

### DIFF
--- a/src/sharepoint/userprofiles.ts
+++ b/src/sharepoint/userprofiles.ts
@@ -106,7 +106,7 @@ export class UserProfileQuery extends SharePointQueryableInstance {
      *
      * @param loginName The account name of the user.
      */
-    public getPropertiesFor(loginName: string): Promise<any[]> {
+    public getPropertiesFor(loginName: string): Promise<any> {
         const q = this.clone(UserProfileQuery, "getpropertiesfor(@v)");
         q.query.add("@v", `'${encodeURIComponent(loginName)}'`);
         return q.get();


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [ ]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #656

#### What's in this Pull Request?

Fixes the issue with getPropertiesFor response type.

Was:

```typescript
public getPropertiesFor(loginName: string): Promise<any[]> {
  const q = this.clone(UserProfileQuery, "getpropertiesfor(@v)");
  q.query.add("@v", `'${encodeURIComponent(loginName)}'`);
  return q.get();
}
```

Should be:

```typescript
public getPropertiesFor(loginName: string): Promise<any[]> {
  const q = this.clone(UserProfileQuery, "getpropertiesfor(@v)");
  q.query.add("@v", `'${encodeURIComponent(loginName)}'`);
  return q.get();
}
```
