### PR TITLE
Implements TimeZone/utcToLocalTime and TimeZone/localTimeToUTC

### DIFF
--- a/tests/sharepoint/regionalsettings.test.ts
+++ b/tests/sharepoint/regionalsettings.test.ts
@@ -27,14 +27,23 @@ describe("RegionalSettings", () => {
     });
 
     describe("timeZone", () => {
+
         it("Should return _api/web/regionalsettings/timezone", () => {
             expect(regionalsettings.timeZone.toUrl()).to.match(toMatchEndRegex("_api/web/regionalsettings/timezone"));
         });
+
     });
 
     describe("timeZones", () => {
+
         it("Should return _api/web/regionalsettings/timezones", () => {
             expect(regionalsettings.timeZones.toUrl()).to.match(toMatchEndRegex("_api/web/regionalsettings/timezones"));
         });
+
+        it("Should return _api/web/regionalsettings/timezones(15)", () => {
+            expect(regionalsettings.timeZones.getById(15).toUrl()).to.match(toMatchEndRegex("_api/web/regionalsettings/timezones(15)"));
+        });
+
     });
+
 });


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [ ]
| New feature?    | [x]
| New sample?      | [ ]
| Related issues?  | mentioned in #659

#### What's in this Pull Request?

The PR implements:
- Getting TimeZone by Id
- TimeZone/utcToLocalTime
- TimeZone/localTimeToUTC

```TypeScript
let regionalSettings = pnp.sp.web.regionalSettings;

let timeZone = await regionalSettings.timeZones.getById(15).get();
console.log(timeZone);

let date1 = '2017-12-08T13:20:00';

let { localTime } = await regionalSettings.timeZone.utcToLocalTime(date); // Receives Date or ISO String
console.log(localTime);

let date2 = new Date();

let { utcTime } = await regionalSettings.timeZones.getById(15).localTimeToUTC(date2 ); // Receives Date or ISO String
console.log(utcTime);
```
