### PR TITLE
Added Refiners to ResultTable interface (SharePoint Search)

### DIFF
--- a/src/sharepoint/search.ts
+++ b/src/sharepoint/search.ts
@@ -680,7 +680,8 @@ export interface ResultTable {
     GroupTemplateId?: string;
     ItemTemplateId?: string;
     Properties?: { Key: string, Value: any, ValueType: string }[];
-    Table: { Rows: { Cells: { Key: string, Value: any, ValueType: string }[] }[] };
+    Table?: { Rows: { Cells: { Key: string, Value: any, ValueType: string }[] }[] };
+    Refiners?: { Entries: { RefinementCount: string; RefinementName: string; RefinementToken: string; RefinementValue: string; }[]; }[];
     ResultTitle?: string;
     ResultTitleUrl?: string;
     RowCount?: number;


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [ ]
| New feature?    | [ x ]
| New sample?      | [ ]
| Related issues?  | 

#### What's in this Pull Request?

Added Refiners to ResultTable interface (SharePoint search).
With Refiners added in this interface we can use these refiners as a result from a SharePoint search query. 