### PR TITLE
Added support to send attachments to recycle bin

### DIFF
--- a/src/sharepoint/attachmentfiles.ts
+++ b/src/sharepoint/attachmentfiles.ts
@@ -70,6 +70,15 @@ export class AttachmentFiles extends SharePointQueryableCollection {
     public deleteMultiple(...files: string[]): Promise<void> {
         return files.reduce((chain, file) => chain.then(() => this.getByName(file).delete()), Promise.resolve());
     }
+
+    /**
+     * Delete multiple attachments from the collection and sends it to recycle bin. Not supported for batching.
+     *
+     * @files name The collection of files to delete
+     */
+    public recycleMultiple(...files: string[]): Promise<void> {
+        return files.reduce((chain, file) => chain.then(() => this.getByName(file).recycle()), Promise.resolve());
+    }
 }
 
 /**
@@ -134,6 +143,18 @@ export class AttachmentFile extends SharePointQueryableInstance {
      */
     public delete(eTag = "*"): Promise<void> {
         return this.postCore({
+            headers: {
+                "IF-Match": eTag,
+                "X-HTTP-Method": "DELETE",
+            },
+        });
+    }
+
+    /**
+     * Delete this attachment file and send it to Recycle Bin
+     */
+    public recycle(eTag = "*"): Promise<void> {
+        return this.clone(AttachmentFile, "recycleObject").postCore({
             headers: {
                 "IF-Match": eTag,
                 "X-HTTP-Method": "DELETE",

--- a/src/sharepoint/attachmentfiles.ts
+++ b/src/sharepoint/attachmentfiles.ts
@@ -152,6 +152,8 @@ export class AttachmentFile extends SharePointQueryableInstance {
 
     /**
      * Delete this attachment file and send it to Recycle Bin
+     * 
+     * @param eTag Value used in the IF-Match header, by default "*"
      */
     public recycle(eTag = "*"): Promise<void> {
         return this.clone(AttachmentFile, "recycleObject").postCore({


### PR DESCRIPTION
By default, when you delete an attachment, its permanently deleted and you can't recover the attachment.

These methods add support to send attachment(s) to recycle bin

| Q               | A
| --------------- | ---
| Bug fix?        | N
| New feature?    | Y
| New sample?      | N
| Related issues?  | NA

#### What's in this Pull Request?

Support to send list item attachments to recycle bin