### PR TITLE
defaultView now returns View not SharePointQueryableInstance

### DIFF
--- a/src/sharepoint/lists.ts
+++ b/src/sharepoint/lists.ts
@@ -4,7 +4,7 @@ import { ContentTypes } from "./contenttypes";
 import { Fields } from "./fields";
 import { Forms } from "./forms";
 import { Subscriptions } from "./subscriptions";
-import { SharePointQueryable, SharePointQueryableInstance, SharePointQueryableCollection } from "./sharepointqueryable";
+import { SharePointQueryable, SharePointQueryableCollection } from "./sharepointqueryable";
 import { SharePointQueryableSecurable } from "./sharepointqueryablesecurable";
 import { Util } from "../utils/util";
 import { TypedHash } from "../collections/collections";
@@ -185,8 +185,8 @@ export class List extends SharePointQueryableSecurable {
      * Gets the default view of this list
      *
      */
-    public get defaultView(): SharePointQueryableInstance {
-        return new SharePointQueryableInstance(this, "DefaultView");
+    public get defaultView(): View {
+        return new View(this, "DefaultView");
     }
 
     /**

--- a/tests/sharepoint/lists.test.ts
+++ b/tests/sharepoint/lists.test.ts
@@ -134,6 +134,12 @@ describe("List", () => {
         });
     });
 
+    describe("defaultView/viewFields", () => {
+        it("should return _api/web/lists/getByTitle('Tasks')/DefaultView/viewfields", () => {
+            expect(list.defaultView.fields.toUrl()).to.match(toMatchEndRegex("_api/web/lists/getByTitle('Tasks')/DefaultView/viewfields"));
+        });
+    });
+
     describe("effectiveBasePermissions", () => {
         it("should return _api/web/lists/getByTitle('Tasks')/EffectiveBasePermissions", () => {
             expect(list.effectiveBasePermissions.toUrl())


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [ ]
| New feature?    | [ ]
| New sample?      | [ ]
| Related issues?  | fixes #692

#### What's in this Pull Request?

Fixes https://github.com/SharePoint/PnP-JS-Core/issues/692, the type of list's defaultView method should be `View`. So it's possible to chain the method with view-specific functionality.
