### PR TITLE
adding support for addUser and addLookup methods on fields collection

### DIFF
--- a/src/sharepoint/types.ts
+++ b/src/sharepoint/types.ts
@@ -1469,3 +1469,8 @@ export interface MenuNodeCollection {
     StartingNodeTitle: string;
     Version: Date;
 }
+
+export enum FieldUserSelectionMode {
+    PeopleAndGroups = 1,
+    PeopleOnly = 0,
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [ ]
| New feature?    | [X]
| New sample?      | [ ]
| Related issues?  | fixes #697

#### What's in this Pull Request?

Adds the ability to add a lookup field as well as a user field through the new addUser and addLookup methods.