### PR TITLE
Added addChoice, addMultiChoice, addBoolean to Fields

### DIFF
--- a/src/sharepoint/types.ts
+++ b/src/sharepoint/types.ts
@@ -358,6 +358,20 @@ export interface XmlSchemaFieldCreationInformation {
     SchemaXml: string;
 }
 
+export interface FieldCreationProperties extends TypedHash<string | number | boolean> {
+    DefaultFormula?: string;
+    Description?: string;
+    EnforceUniqueValues?: boolean;
+    FieldTypeKind?: number;
+    Group?: string;
+    Hidden?: boolean;
+    Indexed?: boolean;
+    Required?: boolean;
+    Title?: string;
+    ValidationFormula?: string;
+    ValidationMessage?: string;
+}
+
 export enum CalendarType {
     Gregorian = 1,
     Japan = 3,
@@ -379,6 +393,11 @@ export enum CalendarType {
 export enum UrlFieldFormatType {
     Hyperlink = 0,
     Image = 1,
+}
+
+export enum ChoiceFieldFormatType {
+    Dropdown,
+    RadioButtons,
 }
 
 export interface BasePermissions {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [ ]
| New feature?    | [x]
| New sample?      | [ ]
| Related issues?  | mentioned in #704 

#### What's in this Pull Request?

Added the following methods to the Fields class:
addChoice
addMultiChoice
addBoolean

Also created a FieldCreationProperties interface which contains the most common field creation properties for sake of intellisense. It extends TypedHash<string | number | boolean> so other properties are also supported (no breaking change).

Also changed the type of the properties argument so that FieldTypeKind is mandatory (could be a breaking change? the FieldTypeKind property is required by the REST API anyway so this would only break already broken code I guess).