### PR TITLE
Skip PagedPrev=TRUE support

### DIFF
--- a/src/sharepoint/items.ts
+++ b/src/sharepoint/items.ts
@@ -54,8 +54,12 @@ export class Items extends SharePointQueryableCollection {
      *
      * @param skip The starting id where the page should start, use with top to specify pages
      */
-    public skip(skip: number): this {
-        this._query.add("$skiptoken", encodeURIComponent(`Paged=TRUE&p_ID=${skip}`));
+    public skip(skip: number, reverse = false): this {
+        if (reverse) {
+            this._query.add("$skiptoken", encodeURIComponent(`Paged=TRUE&PagedPrev=TRUE&p_ID=${skip}`));
+        } else {
+            this._query.add("$skiptoken", encodeURIComponent(`Paged=TRUE&p_ID=${skip}`));
+        }
         return this;
     }
 
@@ -69,7 +73,7 @@ export class Items extends SharePointQueryableCollection {
 
     /**
      * Gets all the items in a list, regardless of count. Does not support batching or caching
-     * 
+     *
      *  @param requestSize Number of items to return in each request (Default: 2000)
      */
     public getAll(requestSize = 2000): Promise<any[]> {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [ ]
| New feature?    | [x]
| New sample?      | [ ]

#### What's in this Pull Request?

Adds support for using skip token with backward direction.

```typescript
console.log(
  await list.items.select('Id').skip(23).top(5).get()
    .then(r => r.map(i => i.Id))
);
console.log(
  await list.items.select('Id').skip(23, true).top(5).get()
    .then(r => r.map(i => i.Id))
);
```

![image](https://user-images.githubusercontent.com/7816483/36340777-9996b82a-13f4-11e8-8a38-873617084928.png)

With this, it's possible to manage back page navigation being on a random paged data page.