### PR TITLE
Added support for social.following endpoints

### DIFF
--- a/src/sharepoint/index.ts
+++ b/src/sharepoint/index.ts
@@ -131,6 +131,13 @@ export {
 } from "./siteusers";
 
 export {
+    ActorType,
+    SocialActorInfo,
+    SocialFollowResult,
+    SocialQuery,
+} from "./social";
+
+export {
     SubscriptionAddResult,
     SubscriptionUpdateResult,
 } from "./subscriptions";

--- a/src/sharepoint/index.ts
+++ b/src/sharepoint/index.ts
@@ -131,8 +131,8 @@ export {
 } from "./siteusers";
 
 export {
-    ActorType,
     SocialActorInfo,
+    SocialActorType,
     SocialFollowResult,
     SocialQuery,
 } from "./social";

--- a/src/sharepoint/rest.ts
+++ b/src/sharepoint/rest.ts
@@ -5,6 +5,7 @@ import { Web } from "./webs";
 import { Util } from "../utils/util";
 import { SharePointQueryable, SharePointQueryableConstructor } from "./sharepointqueryable";
 import { UserProfileQuery } from "./userprofiles";
+import { SocialQuery } from "./social";
 import { NavigationService, INavigationService } from "./navigation";
 import { ODataBatch } from "./batch";
 import { UrlException } from "../utils/exceptions";
@@ -107,6 +108,13 @@ export class SPRest {
      */
     public get profiles(): UserProfileQuery {
         return new UserProfileQuery(this._baseUrl).configure(this._options);
+    }
+
+    /**
+     * Access to social methods
+     */
+    public get social(): SocialQuery {
+        return new SocialQuery(this._baseUrl).configure(this._options);
     }
 
     /**

--- a/src/sharepoint/social.ts
+++ b/src/sharepoint/social.ts
@@ -52,8 +52,8 @@ export class SocialQuery extends SharePointQueryableInstance {
         return JSON.stringify({
             "actor":
                 Util.extend({
-                    "__metadata": { "type": "SP.Social.SocialActorInfo" },
                     Id: null,
+                    "__metadata": { "type": "SP.Social.SocialActorInfo" },
                 }, actorInfo),
         });
     }

--- a/src/sharepoint/social.ts
+++ b/src/sharepoint/social.ts
@@ -65,7 +65,7 @@ export class SocialQuery extends SharePointQueryableInstance {
  */
 export interface SocialActorInfo {
     AccountName?: string;
-    ActorType: ActorType;
+    ActorType: SocialActorType;
     ContentUri?: string;
     Id?: string;
     TagGuid?: string;
@@ -75,7 +75,7 @@ export interface SocialActorInfo {
  * Social actor type
  *
  */
-export enum ActorType {
+export enum SocialActorType {
     User = 0,
     Document = 1,
     Site = 2,

--- a/src/sharepoint/social.ts
+++ b/src/sharepoint/social.ts
@@ -1,0 +1,94 @@
+import { SharePointQueryable, SharePointQueryableInstance } from "./sharepointqueryable";
+import { ODataValue } from "../odata/parsers";
+import { Util } from "../utils/util";
+
+export class SocialQuery extends SharePointQueryableInstance {
+
+    /**
+     * Creates a new instance of the SocialQuery class
+     *
+     * @param baseUrl The url or SharePointQueryable which forms the parent of this social query
+     */
+    constructor(baseUrl: string | SharePointQueryable, path = "_api/social.following") {
+        super(baseUrl, path);
+    }
+
+    /**
+     * Makes the current user start following a user, document, site, or tag
+     *
+     * @param actorInfo The actor to start following
+     */
+    public follow(actorInfo: SocialActorInfo): Promise<SocialFollowResult> {
+        return this.clone(SocialQuery, "follow")
+            .postCore({ body: this.createSocialActorInfoRequestBody(actorInfo) }, ODataValue<number>());
+    }
+
+    /**
+     * Indicates whether the current user is following a specified user, document, site, or tag
+     *
+     * @param actorInfo The actor to find the following status for
+     */
+    public isFollowed(actorInfo: SocialActorInfo): Promise<boolean> {
+        return this.clone(SocialQuery, "isfollowed")
+            .postCore({ body: this.createSocialActorInfoRequestBody(actorInfo) }, ODataValue<boolean>());
+    }
+
+    /**
+     * Makes the current user stop following a user, document, site, or tag
+     *
+     * @param actorInfo The actor to stop following
+     */
+    public stopFollowing(actorInfo: SocialActorInfo): Promise<void> {
+        return this.clone(SocialQuery, "stopfollowing")
+            .postCore({ body: this.createSocialActorInfoRequestBody(actorInfo) });
+    }
+
+    /**
+     * Creates SocialActorInfo request body
+     *
+     * @param actorInfo The actor to create request body
+     */
+    private createSocialActorInfoRequestBody(actorInfo: SocialActorInfo): string {
+        return JSON.stringify({
+            "actor":
+                Util.extend({
+                    "__metadata": { "type": "SP.Social.SocialActorInfo" },
+                    Id: null,
+                }, actorInfo),
+        });
+    }
+}
+
+/**
+ * Social actor info
+ *
+ */
+export interface SocialActorInfo {
+    AccountName?: string;
+    ActorType: ActorType;
+    ContentUri?: string;
+    Id?: string;
+    TagGuid?: string;
+}
+
+/**
+ * Social actor type
+ *
+ */
+export enum ActorType {
+    User = 0,
+    Document = 1,
+    Site = 2,
+    Tag = 3,
+}
+
+/**
+ * Result from following
+ *
+ */
+export enum SocialFollowResult {
+    Ok = 0,
+    AlreadyFollowing = 1,
+    LimitReached = 2,
+    InternalError = 3,
+}

--- a/tests/sharepoint/social.test.ts
+++ b/tests/sharepoint/social.test.ts
@@ -1,0 +1,14 @@
+import { expect } from "chai";
+import { SocialQuery } from "../../src/sharepoint/social";
+
+describe("Social", () => {
+    let socialQuery: SocialQuery;
+
+    beforeEach(() => {
+        socialQuery = new SocialQuery("_api");
+    });
+
+    it("Should be an object", () => {
+        expect(socialQuery).to.be.a("object");
+    });
+});


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [ ]
| New feature?    | [x]
| New sample?      | [ ]

#### What's in this Pull Request?

Added support for following endpoints:
```
_api/social.following/follow
_api/social.following/stopFollowing
_api/social.following/isFollowed
```

Example usage:
`pnp.sp.social.follow({ActorType: SocialActorType.Site, ContentUri: "https://siteUrl" });`