### PR TITLE
Added support for setting user profile properties

### DIFF
--- a/src/sharepoint/userprofiles.ts
+++ b/src/sharepoint/userprofiles.ts
@@ -177,6 +177,42 @@ export class UserProfileQuery extends SharePointQueryableInstance {
     }
 
     /**
+     * Sets single value User Profile property
+     *
+     * @param accountName The account name of the user
+     * @param propertyName Property name
+     * @param propertyValue Property value
+     */
+    public setSingleValueProfileProperty(accountName: string, propertyName: string, propertyValue: string): Promise<void> {
+        const postBody: string = JSON.stringify({
+            accountName: accountName,
+            propertyName: propertyName,
+            propertyValue: propertyValue,
+        });
+
+        return this.clone(UserProfileQuery, "SetSingleValueProfileProperty")
+            .postCore({ body: postBody });
+    }
+
+    /**
+     * Sets multi valued User Profile property
+     *
+     * @param accountName The account name of the user
+     * @param propertyName Property name
+     * @param propertyValues Property values
+     */
+    public setMultiValuedProfileProperty(accountName: string, propertyName: string, propertyValues: string[]): Promise<void> {
+        const postBody: string = JSON.stringify({
+            accountName: accountName,
+            propertyName: propertyName,
+            propertyValues: propertyValues,
+        });
+
+        return this.clone(UserProfileQuery, "SetMultiValuedProfileProperty")
+            .postCore({ body: postBody });
+    }
+
+    /**
      * Provisions one or more users' personal sites. (My Site administrator on SharePoint Online only)
      *
      * @param emails The email addresses of the users to provision sites for


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | [ ]
| New feature?    | [x]
| New sample?      | [ ]

#### What's in this Pull Request?

Added support for setting user profile properties using following endpoints:
```
/_api/SP.UserProfiles.PeopleManager/SetSingleValueProfileProperty
/_api/SP.UserProfiles.PeopleManager/SetMultiValuedProfileProperty
```

Example usage:
```
pnp.sp.profiles.setSingleValueProfileProperty("i:0#.f|membership|user@contoso.onmicrosoft.com", "AboutMe", "Lorem ipsum");
pnp.sp.profiles.setMultiValuedProfileProperty("i:0#.f|membership|user@contoso.onmicrosoft.com", "SPS-Skills", ["SharePoint", "Azure"]);
```