### PR TITLE
Add support for `expose` in `getAll`

### DIFF
--- a/src/sharepoint/items.ts
+++ b/src/sharepoint/items.ts
@@ -81,48 +81,24 @@ export class Items extends SharePointQueryableCollection {
 
         Logger.write("Calling items.getAll should be done sparingly. Ensure this is the correct choice. If you are unsure, it is not.", LogLevel.Warning);
 
-        // this will be used for the actual query
-        // and we set no metadata here to try and reduce traffic
-        const items = new Items(this, "").top(requestSize).configure({
-            headers: {
-                "Accept": "application/json;odata=nometadata",
-            },
-        });
+        // this will eventually hold the items we return
+        const itemsCollector: any[] = [];
 
-        // let's copy over the odata query params that can be applied
-        // $top - allow setting the page size this way (override what we did above)
-        // $select - allow picking the return fields (good behavior)
-        // $filter - allow setting a filter, though this may fail for large lists
-        this.query.getKeys()
-            .filter(k => /^\$select$|^\$filter$|^\$top$/.test(k.toLowerCase()))
-            .reduce((i, k) => {
-                i.query.add(k, this.query.get(k));
-                return i;
-            }, items);
+        // action that will gather up our results recursively
+        function gatherer (last: Promise<PagedItemCollection<any>>): any {
+            return last.then((pageResult: PagedItemCollection<any>) => {
 
-        // give back the promise
-        return new Promise((resolve, reject) => {
+                [].push.apply(itemsCollector, pageResult.results);
 
-            // this will eventually hold the items we return
-            const itemsCollector: any[] = [];
-
-            // action that will gather up our results recursively
-            const gatherer = (last: PagedItemCollection<any>) => {
-
-                // collect that set of results
-                [].push.apply(itemsCollector, last.results);
-
-                // if we have more, repeat - otherwise resolve with the collected items
-                if (last.hasNext) {
-                    last.getNext().then(gatherer).catch(reject);
-                } else {
-                    resolve(itemsCollector);
+                if (pageResult.hasNext) {
+                    return gatherer(pageResult.getNext());
                 }
-            };
 
-            // start the cycle
-            items.getPaged().then(gatherer).catch(reject);
-        });
+                return itemsCollector;
+            });
+        }
+
+        return gatherer(this.top(requestSize).getPaged());
     }
 
     /**


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Feature enhancement [ x ]

#### What's in this Pull Request?

This commits add support for `expose` to the new `getAll` method.
We discussed this on gitter, and I understand that `expose` was deliberately excluded from `getAll` because of performance reasons. 
While I understand the decision I still would like the ability to get all data in the exact same was as with `items.get()`. My fix will re-use the original query, so it should "just work", even if the original query would change layout somehow (unlikely).

The reason I want this is that we often use pnp for small snippets (using [tick](https://www.npmjs.com/package/tick-cli)), and then we need to run `expose` to do one-time jobs where we need more data, even if they are slow.

P.S. I was originally suppose to just make an issue, but wanted to try making a PR, so this is my first to this repo. I really like pnp, and making PRs would be a nice way to help out.
