### PR TITLE
fixed rare compiler error due type checkings

### DIFF
--- a/src/sharepoint/types.ts
+++ b/src/sharepoint/types.ts
@@ -358,7 +358,7 @@ export interface XmlSchemaFieldCreationInformation {
     SchemaXml: string;
 }
 
-export interface FieldCreationProperties extends TypedHash<string | number | boolean> {
+export interface FieldCreationProperties extends TypedHash<string | number | boolean | undefined > {
     DefaultFormula?: string;
     Description?: string;
     EnforceUniqueValues?: boolean;


### PR DESCRIPTION
at line 361 some compilers fails due undefined is missing.

| Q                        | A
| ------------------ | ---
| Bug fix?              | [ x]
| New feature?     | [ ]
| New sample?     | [ ]
| Related issues?  | fixes #X, partially #Y, mentioned in #Z

#### What's in this Pull Request?

Rare compiler errors occurs due missing type at line 361.
Example error message : 'string | undefined' is not assignable to string index type 'string | number | boolean'.

It's not a issue but might be problematic for some new users.
