### PR TITLE
adds the addClientSidePageByPath method to the Web class

### DIFF
--- a/src/sharepoint/webs.ts
+++ b/src/sharepoint/webs.ts
@@ -551,6 +551,17 @@ export class Web extends SharePointQueryableShareableWeb {
     public addClientSidePage(pageName: string, title = pageName.replace(/\.[^/.]+$/, ""), libraryTitle = "Site Pages"): Promise<ClientSidePage> {
         return ClientSidePage.create(this.lists.getByTitle(libraryTitle), pageName, title);
     }
+
+    /**
+     * Creates a new client side page using the library path
+     *
+     * @param pageName Name of the new page
+     * @param listRelativePath The server relative path to the list's root folder (including /sites/ if applicable)
+     * @param title Display title of the new page
+     */
+    public addClientSidePageByPath(pageName: string, listRelativePath: string, title = pageName.replace(/\.[^/.]+$/, "")): Promise<ClientSidePage> {
+        return ClientSidePage.create(this.getList(listRelativePath), pageName, title);
+    }
 }
 
 /**


### PR DESCRIPTION
| Q                        | A
| ------------------ | ---
| Bug fix?              | [X]
| New feature?     | [ ]
| New sample?     | [ ]
| Related issues?  | fixes #806 #784

#### What's in this Pull Request?

Adds the addClientSidePageByPath method to the Web class allowing you to create a client side page using the library path.