### PR TITLE
Added getRootWeb method to Site class

### DIFF
--- a/src/sharepoint/site.ts
+++ b/src/sharepoint/site.ts
@@ -46,6 +46,14 @@ export class Site extends SharePointQueryableInstance {
     }
 
     /**
+     * Gets a Web instance representing the root web of the site collection
+     * correctly setup for chaining within the library
+     */
+     public getRootWeb(): Promise<Web> {
+        return this.rootWeb.select("Url").get().then(web => new Web(web.Url));
+    }
+
+    /**
      * Gets the context information for this site collection
      */
     public getContextInfo(): Promise<ContextInfo> {


### PR DESCRIPTION
| Q                        | A
| ------------------ | ---
| Bug fix?              | [ ]
| New feature?     | [X]
| New sample?     | [ ]
| Related issues?  | fixes #790

#### What's in this Pull Request?

Adds a getRootWeb() method to Site class to get a Web instance correctly established for chaining.